### PR TITLE
Install instructions from git and example-query.sparql

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ Each Triple Pattern Fragment offers:
 This client requires [Node.js](http://nodejs.org/) 0.10 or higher
 and is tested on OSX and Linux.
 To install, execute:
+
 ```bash
 $ [sudo] npm install -g ldf-client
+```
+To install from git, execute:
+
+```bash
+$ git clone git@github.com:LinkedDataFragments/Client.js
+$ cd Client.js
+$ npm install .
 ```
 
 ## Launching queries through the standalone application
@@ -38,6 +46,12 @@ $ ldf-client query.sparql
 ```
 Here, `query.sparql` contains your query;
 alternatively, you can pass the query as a string.
+
+When installed from git, you can run:
+
+```bash
+$ ./bin/ldf-client example-query.sparql
+```
 
 By default, the LDF server [data.linkeddatafragments.org](http://data.linkeddatafragments.org/) is used,
 but you can specify your own by creating your own `config.json` based on `config-default.json`:

--- a/example-query.sparql
+++ b/example-query.sparql
@@ -1,0 +1,1 @@
+SELECT * { ?s ?p <http://dbpedia.org/resource/Ghent>. } LIMIT 10


### PR DESCRIPTION
This commit request explains the case of installation from a local git checkout.

It also adds an `example-query.sparql` to make it even easier to have a `hello world` working immediately.

Open for improvements :-) Maybe an `npm` commands can be added that will allow

```
$ ldf-client example-query.sparql
```

without needing the give the explicit ./bin/ path. 
