### PR TITLE
Prevent new requests after abortAll has been called.

### DIFF
--- a/lib/util/HttpClient.js
+++ b/lib/util/HttpClient.js
@@ -147,11 +147,14 @@ HttpClient.prototype._startRequest = function (request) {
   };
 };
 
-/** Aborts all active and pending requests. */
+/** Aborts all active and pending requests and prevents the HttpClient from accepting new requests. */
 HttpClient.prototype.abortAll = function () {
   this._queued = [];
   for (var id in this._active)
     this._active[id].abort();
+  this.request = function () {
+    throw new Error('Client no longer accepts requests after aborting.');
+  };
 };
 
 module.exports = HttpClient;

--- a/test/util/HttpClient-test.js
+++ b/test/util/HttpClient-test.js
@@ -138,6 +138,17 @@ describe('HttpClient', function () {
       request.emit('error', error);
     });
   });
+
+  describe('An HttpClient aborting all connections', function () {
+    var request = new EventEmitter();
+    var createRequest = sinon.stub().returns(request);
+    var client = new HttpClient({ request: createRequest });
+
+    it('should emit an error on new requests', function () {
+      client.abortAll();
+      expect(function () { client.get('http://example.org/foo'); }).to.throw();
+    });
+  });
 });
 
 // Creates a dummy HTTP response


### PR DESCRIPTION
If the client received a partial result when abortAll was called it was possible for the process to continue since the relevant metadata might have been received already.