### PR TITLE
Add deprecation note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This project has been deprecated in favor of [Comunica SPARQL](https://github.com/comunica/comunica/tree/master/packages/actor-init-sparql), which is part of the [Comunica](https://github.com/comunica/comunica) platform. It can do everything Client.js can do, and more.
+
+-----
+
 # Linked Data Fragments Client
 <img src="http://linkeddatafragments.org/images/logo.svg" width="200" align="right" alt="" />
 


### PR DESCRIPTION
As discussed in https://github.com/LinkedDataFragments/jQuery-Widget.js/issues/13, this adds a deprecation note to the README.

Others things we need to do after merging this:
* Add a deprecation warning in the repo description.
* Remove it from the LDF website(?)
* Add a deprecation warning to the npm package.
* Archive the GitHub repo.